### PR TITLE
feat: update panel state when round ends

### DIFF
--- a/panorama/layout/custom_game/hud_workshop_testbed.xml
+++ b/panorama/layout/custom_game/hud_workshop_testbed.xml
@@ -19,6 +19,10 @@
       const seconds = parseInt(event.cur_time % 60);
       $("#timer").text = `第 ${event.round_count} 轮开始于 ${minutes}:${seconds} 持续到 ${minutes+5}:${seconds}`;
     });
+
+    GameEvents.Subscribe("roundEnd", function (event) {
+      $("#timer").text = `第 ${event.round_count} 轮结束`;
+    });
   </script>
 
 <!--


### PR DESCRIPTION
Update panel state to `第 ${event.round_count} 轮结束` when round ends.